### PR TITLE
Fix error-state placeholder markup

### DIFF
--- a/script.js
+++ b/script.js
@@ -263,7 +263,7 @@ const handleGenerate = (event) => {
     strengthBar.style.width = '10%';
     strengthBar.style.background = 'var(--danger)';
     passwordOutput.value = error.message;
-    passwordList.innerHTML = '<p class=\"password-list__placeholder\">Adjust your settings to generate a password.</p>';
+    passwordList.innerHTML = '<p class="password-list__placeholder">Adjust your settings to generate a password.</p>';
   }
 };
 


### PR DESCRIPTION
## Summary
- fix the escaped quotes in the error-state placeholder so the class name is applied correctly

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d182427c98832cb99241f0233b6f30